### PR TITLE
[DOPS-985] Move sora-net docker images to the new registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,8 +20,8 @@ pipeline {
 
           DOCKER_NETWORK = "${env.CHANGE_ID}-${env.GIT_COMMIT}-${BUILD_NUMBER}"
           writeFile file: ".env", text: "SUBNET=${DOCKER_NETWORK}"
-          withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
-                      sh "docker login nexus.iroha.tech:19004 -u ${login} -p '${password}'"
+          withCredentials([usernamePassword(credentialsId: 'bot-soranet-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
+            sh "docker login docker.soramitsu.co.jp -u ${login} -p '${password}'"
           }
 
           withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
@@ -100,12 +100,12 @@ pipeline {
       steps {
         script {
           if (env.BRANCH_NAME ==~ /(master|develop|reserved)/ || env.TAG_NAME) {
-                withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'login', passwordVariable: 'password')]) {
+                withCredentials([usernamePassword(credentialsId: 'bot-soranet-rw', usernameVariable: 'login', passwordVariable: 'password')]) {
                   TAG = env.TAG_NAME ? env.TAG_NAME : env.BRANCH_NAME
                   iC = docker.image("gradle:4.10.2-jdk8-slim")
                   iC.inside(" -e JVM_OPTS='-Xmx3200m' -e TERM='dumb'"+
                   " -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp"+
-                  " -e DOCKER_REGISTRY_URL='https://nexus.iroha.tech:19004'"+
+                  " -e DOCKER_REGISTRY_URL='https://docker.soramitsu.co.jp'"+
                   " -e DOCKER_REGISTRY_USERNAME='${login}'"+
                   " -e DOCKER_REGISTRY_PASSWORD='${password}'"+
                   " -e TAG='${TAG}'") {

--- a/deploy/docker-compose.eth.yml
+++ b/deploy/docker-compose.eth.yml
@@ -17,7 +17,7 @@ services:
       - d3-network
 
   d3-eth-deposit:
-    image: nexus.iroha.tech:19004/soranet/eth-deposit:develop
+    image: docker.soramitsu.co.jp/soranet/eth-deposit:develop
     container_name: d3-eth-deposit
     restart: on-failure
     env_file:
@@ -32,7 +32,7 @@ services:
       - d3-network
 
   d3-eth-testing:
-    image: nexus.iroha.tech:19004/soranet/eth-testing-endpoints:develop
+    image: docker.soramitsu.co.jp/soranet/eth-testing-endpoints:develop
     container_name: d3-eth-testing
     restart: on-failure
     volumes:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: nexus.iroha.tech:19004/soramitsu/chain-adapter:develop
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:develop
     container_name: d3-chain-adapter
     restart: on-failure
     depends_on:
@@ -67,7 +67,7 @@ services:
       - d3-network
 
   data-collector:
-    image: nexus.iroha.tech:19004/soranet/data-collector:develop
+    image: docker.soramitsu.co.jp/soranet/data-collector:develop
     container_name: "data-collector"
     restart: on-failure
     ports:
@@ -98,7 +98,7 @@ services:
       - d3-network
 
   d3-brvs:
-    image: nexus.iroha.tech:19004/soranet/brvs-core:develop
+    image: docker.soramitsu.co.jp/soranet/brvs-core:develop
     container_name: d3-brvs
     ports:
       - 8080:8080


### PR DESCRIPTION
# Task

[DOPS-985]: Move sora-net docker images to the new registry.

## Changes

1. Harbor registry used.

## Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-985]: https://soramitsu.atlassian.net/browse/DOPS-985