### PR TITLE
fix proof hash

### DIFF
--- a/eth-bridge/src/main/kotlin/jp/co/soramitsu/soranet/eth/bridge/ReferendumHashProofHandler.kt
+++ b/eth-bridge/src/main/kotlin/jp/co/soramitsu/soranet/eth/bridge/ReferendumHashProofHandler.kt
@@ -93,8 +93,7 @@ class ReferendumHashProofHandler(
     }
 
     private fun createProof(proof: String): String {
-        val hash = hashToProve(proof)
-        val signatureString = deployHelper.signUserData(hash)
+        val signatureString = deployHelper.signUserData(hashToProve(hash))
         val vrs = extractVRS(signatureString)
         val v = vrs.v.toString(16).replace("0x", "")
         val r = Hex.encodeHexString(vrs.r).replace("0x", "")
@@ -102,7 +101,7 @@ class ReferendumHashProofHandler(
         val signature = VRSSignature(v, r, s)
 
         val referendumHashProof = ReferendumHashProof(
-            hash,
+            proof,
             signature
         )
         return gson.toJson(referendumHashProof).irohaEscape()

--- a/eth-bridge/src/main/kotlin/jp/co/soramitsu/soranet/eth/bridge/ReferendumHashProofHandler.kt
+++ b/eth-bridge/src/main/kotlin/jp/co/soramitsu/soranet/eth/bridge/ReferendumHashProofHandler.kt
@@ -14,6 +14,7 @@ import iroha.protocol.Commands
 import jp.co.soramitsu.soranet.eth.sidechain.util.DeployHelper
 import jp.co.soramitsu.soranet.eth.sidechain.util.VRSSignature
 import jp.co.soramitsu.soranet.eth.sidechain.util.extractVRS
+import jp.co.soramitsu.soranet.eth.sidechain.util.hashToProve
 import mu.KLogging
 import org.apache.commons.codec.binary.Hex
 import org.web3j.crypto.Credentials
@@ -91,7 +92,8 @@ class ReferendumHashProofHandler(
             null
     }
 
-    private fun createProof(hash: String): String {
+    private fun createProof(proof: String): String {
+        val hash = hashToProve(proof)
         val signatureString = deployHelper.signUserData(hash)
         val vrs = extractVRS(signatureString)
         val v = vrs.v.toString(16).replace("0x", "")

--- a/eth-bridge/src/main/kotlin/jp/co/soramitsu/soranet/eth/bridge/ReferendumHashProofHandler.kt
+++ b/eth-bridge/src/main/kotlin/jp/co/soramitsu/soranet/eth/bridge/ReferendumHashProofHandler.kt
@@ -11,12 +11,8 @@ import com.d3.commons.util.GsonInstance
 import com.d3.commons.util.irohaEscape
 import iroha.protocol.BlockOuterClass
 import iroha.protocol.Commands
-import jp.co.soramitsu.soranet.eth.sidechain.util.DeployHelper
-import jp.co.soramitsu.soranet.eth.sidechain.util.VRSSignature
-import jp.co.soramitsu.soranet.eth.sidechain.util.extractVRS
-import jp.co.soramitsu.soranet.eth.sidechain.util.hashToProve
+import jp.co.soramitsu.soranet.eth.sidechain.util.*
 import mu.KLogging
-import org.apache.commons.codec.binary.Hex
 import org.web3j.crypto.Credentials
 
 const val SORA_PROOF_DOMAIN = "@soraProof"
@@ -93,12 +89,8 @@ class ReferendumHashProofHandler(
     }
 
     private fun createProof(proof: String): String {
-        val signatureString = deployHelper.signUserData(hashToProve(hash))
-        val vrs = extractVRS(signatureString)
-        val v = vrs.v.toString(16).replace("0x", "")
-        val r = Hex.encodeHexString(vrs.r).replace("0x", "")
-        val s = Hex.encodeHexString(vrs.s).replace("0x", "")
-        val signature = VRSSignature(v, r, s)
+        val signatureString = deployHelper.signUserData(hashToProve(proof))
+        val signature = extractVRSSignature(signatureString)
 
         val referendumHashProof = ReferendumHashProof(
             proof,

--- a/eth-bridge/src/main/kotlin/jp/co/soramitsu/soranet/eth/bridge/WithdrawalProofHandler.kt
+++ b/eth-bridge/src/main/kotlin/jp/co/soramitsu/soranet/eth/bridge/WithdrawalProofHandler.kt
@@ -17,7 +17,6 @@ import jp.co.soramitsu.soranet.eth.provider.EthAddressProvider
 import jp.co.soramitsu.soranet.eth.provider.EthTokensProvider
 import jp.co.soramitsu.soranet.eth.sidechain.util.*
 import mu.KLogging
-import org.apache.commons.codec.binary.Hex
 import org.web3j.crypto.Credentials
 import org.web3j.crypto.WalletUtils
 import java.math.BigDecimal
@@ -137,11 +136,7 @@ class WithdrawalProofHandler(
                     beneficiary
                 )
         val signatureString = deployHelper.signUserData(hash)
-        val vrs = extractVRS(signatureString)
-        val v = vrs.v.toString(16).replace("0x", "")
-        val r = Hex.encodeHexString(vrs.r).replace("0x", "")
-        val s = Hex.encodeHexString(vrs.s).replace("0x", "")
-        val signature = VRSSignature(v, r, s)
+        val signature = extractVRSSignature(signatureString)
 
         val withdrawalProof = WithdrawalProof(
             accountId,

--- a/eth-core/src/main/kotlin/jp/co/soramitsu/soranet/eth/sidechain/util/Crypto.kt
+++ b/eth-core/src/main/kotlin/jp/co/soramitsu/soranet/eth/sidechain/util/Crypto.kt
@@ -5,6 +5,7 @@
 
 package jp.co.soramitsu.soranet.eth.sidechain.util
 
+import org.apache.commons.codec.binary.Hex
 import org.web3j.crypto.ECKeyPair
 import org.web3j.crypto.Hash
 import org.web3j.crypto.Sign
@@ -140,4 +141,15 @@ fun extractVRS(signature: String): VRS {
         v += BigInteger.valueOf(27)
     }
     return VRS(v, r, s)
+}
+
+/**
+ * Convert to Ethereum-compatible format of VRS Signature
+ */
+fun extractVRSSignature(signature: String): VRSSignature {
+    val vrs = extractVRS(signature)
+    val v = vrs.v.toString(16).replace("0x", "")
+    val r = Hex.encodeHexString(vrs.r).replace("0x", "")
+    val s = Hex.encodeHexString(vrs.s).replace("0x", "")
+    return VRSSignature(v, r, s)
 }


### PR DESCRIPTION
Get sha3 hash from proof before signing.

See https://github.com/soramitsu/soranet-eth/blob/develop/notary-eth-integration-test/src/main/kotlin/jp/co/soramitsu/soranet/eth/integration/helper/ContractTestHelper.kt#L199